### PR TITLE
Add standard "About Ably" info to all public repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Ably Node.js and Browser Typescript example
 
+_[Ably](https://ably.com) is the platform that powers synchronized digital experiences in realtime. Whether attending an event in a virtual venue, receiving realtime financial information, or monitoring live car performance data – consumers simply expect realtime digital experiences as standard. Ably provides a suite of APIs to build, extend, and deliver powerful digital experiences in realtime for more than 250 million devices across 80 countries each month. Organizations like Bloomberg, HubSpot, Verizon, and Hopin depend on Ably’s platform to offload the growing complexity of business-critical realtime data synchronization at global scale. For more information, see the [Ably documentation](https://ably.com/documentation)._
+
 This repo contains the simplest possible example of how to use the [Ably JS library](https://github.com/ably/ably-js) with TypeScript and [the JSPM package manager](http://jspm.io/).
 
 ## Running Node.js Typescript example


### PR DESCRIPTION
## Description

Add standard "About Ably" info to all public repos

* [DOC-197](https://ably.atlassian.net/browse/DOC-197).

## Review

Please check the intro section to the README:
:
* [README](README.md)